### PR TITLE
corrigido migration

### DIFF
--- a/db/migrate/20141112191325_alter_template_name_in_email_reports.rb
+++ b/db/migrate/20141112191325_alter_template_name_in_email_reports.rb
@@ -1,6 +1,6 @@
 class AlterTemplateNameInEmailReports < ActiveRecord::Migration
   def change
-    rename_column :email_reports, :template_name, :email_template_id
-    change_column :email_reports, :email_template_id, :integer, null: false
+    remove_column :email_reports, :template_name
+    add_column :email_reports, :email_template_id, :integer, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,6 @@ ActiveRecord::Schema.define(version: 20141112191325) do
 
   create_table "email_reports", force: true do |t|
     t.string   "email_to"
-    t.integer  "email_template_id",             null: false
     t.text     "data"
     t.integer  "status",            default: 0, null: false
     t.datetime "created_at"
@@ -23,6 +22,7 @@ ActiveRecord::Schema.define(version: 20141112191325) do
     t.string   "reply_to"
     t.string   "cc"
     t.string   "bcc"
+    t.integer  "email_template_id",             null: false
   end
 
   create_table "email_templates", force: true do |t|


### PR DESCRIPTION
Foi necessário alterar a migration pois não estava rodando.
Caso fosse rodar a migration anteriormente com tabelas populadas, ocasionava um erro. O correto é remover a coluna com todos os dados antes e adicionar a nova.
