### PR TITLE
Fixes a bug related to filter params on EmailRequest index page

### DIFF
--- a/app/controllers/email_requests_controller.rb
+++ b/app/controllers/email_requests_controller.rb
@@ -8,7 +8,10 @@ class EmailRequestsController < ApplicationController
     @email_templates = EmailTemplate.availables
   end
 
+  private
   def filter_params
-    params.permit(:status, :email_template_id)
+    @result ||= params.permit(:status, :email_template_id)
+
+    @result.reject{|field, value| value.blank?}
   end
 end

--- a/spec/controllers/email_requests_controller_spec.rb
+++ b/spec/controllers/email_requests_controller_spec.rb
@@ -57,6 +57,14 @@ describe EmailRequestsController, type: :controller do
         expect(assigns(:email_requests)).to eq [email_request]
       end
     end
+
+    context "with email_template_id and status with empty values" do
+
+      it "returns an array with all email_requests ordered by created_at" do
+        get :index, email_template_id: '', status: ''
+        expect(assigns :email_requests).to eq [email_request_2, email_request_1]
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Fixes when empty string is given to EmailRequestsController for filtering index list. It should ignore the filter.
